### PR TITLE
Fix crashes from malformed translated format strings (#75, #80):

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,3 +38,15 @@ jobs:
         with:
           name: unit-test-report
           path: app/build/reports/tests/testDebugUnitTest/
+
+      # Lint validates translated format strings (StringFormatInvalid/StringFormatMatches),
+      # so a malformed community translation fails CI instead of crashing the app.
+      - name: Run Android lint
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-debug.html

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.cemcakmak.hydrotracker"
         minSdk = 26
         targetSdk = 37
-        versionCode = 34
-        versionName = "1.5"
+        versionCode = 35
+        versionName = "1.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -72,6 +72,11 @@ android {
         unitTests {
             isIncludeAndroidResources = true
         }
+    }
+    lint {
+        // Baseline records pre-existing issues; any NEW lint error (e.g. a malformed
+        // translated format string via StringFormatInvalid/StringFormatMatches) fails the build.
+        baseline = file("lint-baseline.xml")
     }
     sourceSets {
         // Robolectric reads the debug variant's merged assets, so expose the exported Room schemas

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,656 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            totalIntake >= 1000 -> &quot;${String.format(&quot;%.1f&quot;, totalIntake / 1000)} L&quot;"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/cemcakmak/hydrotracker/data/database/entities/DailySummary.kt"
+            line="54"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="WrongConstant"
+        message="Must be one of: Composition.PRIMITIVE_CLICK, Composition.PRIMITIVE_THUD, Composition.PRIMITIVE_SPIN, Composition.PRIMITIVE_QUICK_RISE, Composition.PRIMITIVE_SLOW_RISE, Composition.PRIMITIVE_QUICK_FALL, Composition.PRIMITIVE_TICK, Composition.PRIMITIVE_LOW_TICK"
+        errorLine1="        val supportedArray = vibrator.arePrimitivesSupported(*primitives.toIntArray())"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/cemcakmak/hydrotracker/utils/SmartHaptics.kt"
+            line="279"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="AppBundleLocaleChanges"
+        message="Found dynamic locale changes, but did not find corresponding Play Core library calls for downloading languages and splitting by language is not disabled in the `bundle` configuration"
+        errorLine1="        config.setLocale(locale)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/cemcakmak/hydrotracker/utils/AppLocale.kt"
+            line="75"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;1024dp&quot;"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/main/res/drawable/github.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;800dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/health_connect.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;384dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/paypal.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;330dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/widget_preview_large.xml"
+            line="12"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 9.6.1 is available: 9.7.0"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/wrapper/gradle-wrapper.properties"
+            line="3"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2026.06.01 is available: 2026.08.00"
+        errorLine1="composeBom = &quot;2026.06.01&quot;"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/libs.versions.toml"
+            line="8"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.material3:material3 than 1.5.0-alpha24 is available: 1.5.0-alpha26"
+        errorLine1="material3-expressive = &quot;1.5.0-alpha24&quot;"
+        errorLine2="                       ~~~~~~~~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/libs.versions.toml"
+            line="9"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation3:navigation3-runtime than 1.1.4 is available: 1.1.6"
+        errorLine1="navigation3 = &quot;1.1.4&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/libs.versions.toml"
+            line="12"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation3:navigation3-ui than 1.1.4 is available: 1.1.6"
+        errorLine1="navigation3 = &quot;1.1.4&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/libs.versions.toml"
+            line="12"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.runtime:runtime-saveable than 1.11.4 is available: 1.12.0"
+        errorLine1="runtimeSaveable = &quot;1.11.4&quot;"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/HydroTracker/gradle/libs.versions.toml"
+            line="30"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;reminder_interval_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="180"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;reminder_interval_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="180"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;reminder_interval_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="180"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;every_x_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="359"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;every_x_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="359"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;every_x_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="359"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;interval_every_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="379"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;interval_every_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="379"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;interval_every_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="379"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;interval_every_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="383"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;interval_every_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="383"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;interval_every_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="383"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;data_delete_entries_affected&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="565"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;data_delete_entries_affected&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="565"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;data_delete_entries_affected&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="565"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;statistics_streak_days&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es-rES/strings.xml"
+            line="856"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;statistics_streak_days&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="856"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;pt&quot; (Portuguese) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;statistics_streak_days&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="856"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;camera&quot; is a common misspelling; did you mean &quot;câmera&quot;?"
+        errorLine1="    &lt;string name=&quot;profile_take_photo_desc&quot;>Use your camera to take a new photo&lt;/string>"
+        errorLine2="                                                    ~~~~~~">
+        <location
+            file="src/main/res/values-pt-rPT/strings.xml"
+            line="169"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;characters&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;character_count&quot;>%1$d/%2$d characters&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="47"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;and&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;beverage_effectiveness_error&quot;>Enter a value between %1$d and %2$d&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="234"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;reminders&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;reminder_preview_auto&quot;>Based on your %1$s goal, you\&apos;ll get about %2$d reminders (one per glass) spread across your %3$d active hours. Roughly every %4$d minutes.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="417"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;entries&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;hc_restored_snackbar&quot;>Restored %1$d entries, skipped %2$d duplicates&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="473"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;entries&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;data_export_success&quot;>Exported %1$d entries&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="640"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;entries&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;data_import_success&quot;>Imported %1$d entries, skipped %2$d duplicates&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="644"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;entries&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;home_snackbar_synced&quot;>Synced %1$d entries from Health Connect&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="792"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;errors&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;home_snackbar_sync_errors&quot;>Sync completed with %1$d errors&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="793"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 26. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location
+            file="src/main/res/mipmap-anydpi-v26"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notif_pause_reminders_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notif_pause_reminders_desc&quot;>Stop hydration reminders until the next day&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="383"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notif_reminders_paused_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notif_reminders_paused_desc&quot;>Hydration reminders are paused until tomorrow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="385"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.about_contributor_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;about_contributor_name&quot; translatable=&quot;false&quot;>Ali Cem Çakmak&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="664"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;date_format_year_month_day&quot;>16-06-2026&lt;/string>"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="src/main/res/values-de-rDE/strings.xml"
+            line="99"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;date_format_year_month_day&quot;>2026-06-16&lt;/string>"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="99"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_young_adult&quot;>18-30 Jahre&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-de-rDE/strings.xml"
+            line="464"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_young_adult&quot;>18-30 ans&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="464"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_adult&quot;>31-50 Jahre&lt;/string>"
+        errorLine2="                                   ~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-de-rDE/strings.xml"
+            line="465"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_adult&quot;>31-50 ans&lt;/string>"
+        errorLine2="                                   ~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="465"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_middle_aged&quot;>51-60 Jahre&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-de-rDE/strings.xml"
+            line="466"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;age_group_middle_aged&quot;>51-60 ans&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="466"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;activity_desc_light&quot;>Leichte Bewegung 1-3 Tage/wöchentlich&lt;/string>"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-de-rDE/strings.xml"
+            line="479"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;activity_desc_light&quot;>Exercice léger 1-3 jours/semaine&lt;/string>"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="479"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;activity_desc_active&quot;>Exercice intense 6-7 jours/semaine&lt;/string>"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr-rFR/strings.xml"
+            line="481"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="IconXmlAndPng"
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_stat_name.xml, src/main/res/drawable-hdpi/ic_stat_name.png">
+        <location
+            file="src/main/res/drawable-xxhdpi/ic_stat_name.png"/>
+        <location
+            file="src/main/res/drawable-xhdpi/ic_stat_name.png"/>
+        <location
+            file="src/main/res/drawable-mdpi/ic_stat_name.png"/>
+        <location
+            file="src/main/res/drawable-hdpi/ic_stat_name.png"/>
+        <location
+            file="src/main/res/drawable-anydpi/ic_stat_name.xml"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/econ01.jpeg` in densityless folder">
+        <location
+            file="src/main/res/drawable/econ01.jpeg"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/lemmesleep247.jpg` in densityless folder">
+        <location
+            file="src/main/res/drawable/lemmesleep247.jpg"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            intent.data = Uri.parse(&quot;package:${context.packageName}&quot;)"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/cemcakmak/hydrotracker/notifications/NotificationPermissionManager.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            intent.data = Uri.parse(&quot;package:${context.packageName}&quot;)"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/cemcakmak/hydrotracker/notifications/NotificationPermissionManager.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+</issues>

--- a/app/src/main/assets/CHANGELOG.md
+++ b/app/src/main/assets/CHANGELOG.md
@@ -1,3 +1,9 @@
+[1.5.1]
+Fixed
+- Fixed the app crashing when picking a beverage other than water in some languages
+- Fixed the app crashing when opening the Statistics tab in some languages
+- Fixed a hint in the custom beverage editor showing "100%%" instead of "100%"
+
 [1.5]
 Added
 - New animation option under Appearance ▸ Interaction & Feedback — you can now switch off the rolling number animation for a simpler one that runs more smoothly on older or slower devices

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/dialogs/CustomWaterDialog.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/dialogs/CustomWaterDialog.kt
@@ -159,7 +159,7 @@ fun CustomWaterDialog(
                                     Text(
                                         stringResource(
                                             R.string.home_label_hydration_percentage,
-                                            (beverage.hydrationMultiplier * 100).toInt()
+                                            "${(beverage.hydrationMultiplier * 100).toInt()}%"
                                         )
                                     )
                                 },
@@ -210,7 +210,7 @@ fun CustomWaterDialog(
                             Text(
                                 text = stringResource(
                                     R.string.home_label_hydration_effectiveness,
-                                    (selectedBeverage.hydrationMultiplier * 100).toInt()
+                                    "${(selectedBeverage.hydrationMultiplier * 100).toInt()}%"
                                 ),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = beverageColors.color

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/dialogs/EditWaterDialog.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/dialogs/EditWaterDialog.kt
@@ -382,7 +382,7 @@ fun EditWaterDialog(
                                         Text(
                                             stringResource(
                                                 R.string.home_label_hydration_percentage,
-                                                (beverage.hydrationMultiplier * 100).toInt()
+                                                "${(beverage.hydrationMultiplier * 100).toInt()}%"
                                             )
                                         )
                                     },

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/sheets/CustomBeverageSheets.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/common/sheets/CustomBeverageSheets.kt
@@ -367,7 +367,7 @@ private fun PresetBeverageSheetContent(
                 Text(
                     text = stringResource(
                         R.string.beverage_hydration_effectiveness,
-                        (type.hydrationMultiplier * 100).toInt()
+                        "${(type.hydrationMultiplier * 100).toInt()}%"
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/history/MonthlyChart.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/history/MonthlyChart.kt
@@ -141,7 +141,7 @@ internal fun MonthlyChartSection(
                 AnimatedStatItem(
                     label = stringResource(R.string.history_stat_success_rate),
                     targetValue = stats.successRate,
-                    formatValue = { stringResource(R.string.percent_format, it.toInt()) },
+                    formatValue = { stringResource(R.string.percent_format, "${it.toInt()}%") },
                     entryDelayMillis = EntryAnimationDefaults.DELAY_MS
                 )
             }

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/home/HomeScreen.kt
@@ -1120,7 +1120,7 @@ private fun EffectiveHydrationCardContent(
                 AnimatedNumber(
                     targetValue = (safeSelected.hydrationMultiplier * 100),
                     formatValue = { value ->
-                        stringResource(R.string.home_label_effective_hydration, value.toInt())
+                        stringResource(R.string.home_label_effective_hydration, "${value.toInt()}%")
                     },
                     style = MaterialTheme.typography.titleSmall,
                     animateEntry = false,

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/settings/BeverageTypesEditScreen.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/settings/BeverageTypesEditScreen.kt
@@ -197,7 +197,7 @@ fun BeverageTypesEditScreen(
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Text(
-                    text = stringResource(R.string.beverage_hydration_short, (multiplier * 100).toInt()),
+                    text = stringResource(R.string.beverage_hydration_short, "${(multiplier * 100).toInt()}%"),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/statistics/StatisticsScreen.kt
@@ -227,7 +227,7 @@ private fun StatisticsContent(
                         bottomEnd = CornerSize(10.dp)
                     ),
                     hapticsEnabled = false,
-                    tooltipText = stringResource(R.string.percent_format, uiState.goalSuccessRate.toInt()),
+                    tooltipText = stringResource(R.string.percent_format, "${uiState.goalSuccessRate.toInt()}%"),
                     formatValue = { it.toInt().toString() },
                     suffix = "%",
                     entryDelayMillis = EntryAnimationDefaults.DELAY_MS

--- a/app/src/main/java/com/cemcakmak/hydrotracker/presentation/statistics/components/OverviewCard.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/presentation/statistics/components/OverviewCard.kt
@@ -90,7 +90,7 @@ fun OverviewCard(
             OverviewCategory(
                 iconRes = R.drawable.check_filled,
                 label = stringResource(R.string.statistics_label_success_rate),
-                value = stringResource(R.string.percent_format, successRate.toInt())
+                value = stringResource(R.string.percent_format, "${successRate.toInt()}%")
             )
         )
         add(

--- a/app/src/main/java/com/cemcakmak/hydrotracker/widgets/HydroLargeWidget.kt
+++ b/app/src/main/java/com/cemcakmak/hydrotracker/widgets/HydroLargeWidget.kt
@@ -318,7 +318,7 @@ private fun LargeContent(state: HydroWidgetState) {
                         )
                     } else {
                         Text(
-                            text = context.getString(R.string.percent_format, percent),
+                            text = context.getString(R.string.percent_format, "$percent%"),
                             style = TextStyle(
                                 color = GlanceTheme.colors.onSurface,
                                 fontSize = (ringSize.value * 0.17f).sp,

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s Milliliter</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d Zeichen</string>
     <!-- ============================================================================
@@ -203,14 +203,14 @@
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Getränk Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Gefäß hinzufügen</string>
     <string name="container_edit_title">Gefäß bearbeiten</string>
@@ -412,7 +412,7 @@
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% Hydration</string>
+    <string name="beverage_hydration_short">%1$s Hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
     <!-- ============================================================================
@@ -727,8 +727,8 @@
     <string name="home_label_time">Zeit</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Benutzerdefiniert</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -760,7 +760,7 @@
     <string name="container_water_bottle">Wasserflasche</string>
     <string name="container_large_bottle">Große Flasche</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% Hydration</string>
+    <string name="home_label_hydration_percentage">%1$s Hydration</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>
     <string name="home_motivation_almost_there">You\'re doing great! Almost there!</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d characters</string>
     <!-- ============================================================================
@@ -203,14 +203,14 @@
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Beverage Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Add Container</string>
     <string name="container_edit_title">Edit Container</string>
@@ -412,7 +412,7 @@
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% hydration</string>
+    <string name="beverage_hydration_short">%1$s hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
     <!-- ============================================================================
@@ -727,8 +727,8 @@
     <string name="home_label_time">Time</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Custom</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -760,7 +760,7 @@
     <string name="container_water_bottle">Water Bottle</string>
     <string name="container_large_bottle">Large Bottle</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% hydration</string>
+    <string name="home_label_hydration_percentage">%1$s hydration</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>
     <string name="home_motivation_almost_there">You\'re doing great! Almost there!</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d caractères</string>
     <!-- ============================================================================
@@ -203,14 +203,14 @@
     <string name="beverage_show_in_quick_add">Afficher dans l\'ajout rapide</string>
     <string name="beverage_hide_from_quick_add">Cacher de l\'ajout rapide</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d % d\'efficacité d\'hydratation</string>
+    <string name="beverage_hydration_effectiveness">%1$s d\'efficacité d\'hydratation</string>
     <string name="beverage_name_label">Nom de la boisson</string>
     <string name="beverage_name_placeholder">ex., Smoothie</string>
-    <string name="beverage_effectiveness_label">Efficacité de l\'hydratation (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Efficacité de l\'hydratation (%)</string>
     <string name="beverage_effectiveness_placeholder">ex., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Entre une valeur entre %1$d et %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% compte le montant total pour atteindre ton objectif</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% compte le montant total pour atteindre ton objectif</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Ajouter un contenant</string>
     <string name="container_edit_title">Modifier le contenant</string>
@@ -412,7 +412,7 @@
     <string name="screen_beverage_types_title">Types de Boisson</string>
     <string name="beverage_types_helper">Boissons disponibles en ajout rapide. Appuie pour modifier, glisse vers pour réordonner.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d% % d\'hydratation</string>
+    <string name="beverage_hydration_short">%1$s d\'hydratation</string>
     <string name="beverage_reset_title">Réinitialiser les Boissons ?</string>
     <string name="beverage_reset_message">Ceci restaure l\'ordre par défaut des boissons, démasque tous les préréglages et supprime toutes les boissons personnalisées. Cette action est irréversible.</string>
     <!-- ============================================================================
@@ -727,8 +727,8 @@
     <string name="home_label_time">Heure</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Merci de saisir une quantité valide (%1$s-%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Efficacité de l\'hydratation : %1$d% %</string>
-    <string name="home_label_effective_hydration">Hydratation Efficace : %1$d% %</string>
+    <string name="home_label_hydration_effectiveness">Efficacité de l\'hydratation : %1$s</string>
+    <string name="home_label_effective_hydration">Hydratation Efficace : %1$s</string>
     <string name="home_option_custom">Personnalisé</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -760,7 +760,7 @@
     <string name="container_water_bottle">Bouteille d\'eau</string>
     <string name="container_large_bottle">Grande bouteille</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d %% d\'hydratation</string>
+    <string name="home_label_hydration_percentage">%1$s d\'hydratation</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Incroyable ! Tu as atteint ton objectif quotidien !</string>
     <string name="home_motivation_almost_there">Tu t\'en sors bien ! Tu y es presque !</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d characters</string>
     <!-- ============================================================================
@@ -203,14 +203,14 @@
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Beverage Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Add Container</string>
     <string name="container_edit_title">Edit Container</string>
@@ -412,7 +412,7 @@
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% hydration</string>
+    <string name="beverage_hydration_short">%1$s hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
     <!-- ============================================================================
@@ -727,8 +727,8 @@
     <string name="home_label_time">Time</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Custom</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -760,7 +760,7 @@
     <string name="container_water_bottle">Water Bottle</string>
     <string name="container_large_bottle">Large Bottle</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% hydration</string>
+    <string name="home_label_hydration_percentage">%1$s hydration</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>
     <string name="home_motivation_almost_there">You\'re doing great! Almost there!</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d %%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d /%2$d karakter</string>
     <!-- ============================================================================
@@ -203,14 +203,14 @@
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Beverage Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Add Container</string>
     <string name="container_edit_title">Edit Container</string>
@@ -412,7 +412,7 @@
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% hydration</string>
+    <string name="beverage_hydration_short">%1$s hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
     <!-- ============================================================================
@@ -727,8 +727,8 @@
     <string name="home_label_time">Time</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Custom</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -760,7 +760,7 @@
     <string name="container_water_bottle">Water Bottle</string>
     <string name="container_large_bottle">Large Bottle</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% hydration</string>
+    <string name="home_label_hydration_percentage">%1$s hydration</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>
     <string name="home_motivation_almost_there">You\'re doing great! Almost there!</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -37,7 +37,7 @@
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
     <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d characters</string>
     <!-- ============================================================================
@@ -202,14 +202,14 @@
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
     <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Beverage Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
     <!-- Container preset sheet -->
     <string name="container_add_title">Add Container</string>
     <string name="container_edit_title">Edit Container</string>
@@ -408,7 +408,7 @@
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
     <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% hydration</string>
+    <string name="beverage_hydration_short">%1$s hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
     <!-- ============================================================================
@@ -722,8 +722,8 @@
     <string name="home_label_time">Time</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Custom</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -755,7 +755,7 @@
     <string name="container_water_bottle">Water Bottle</string>
     <string name="container_large_bottle">Large Bottle</string>
     <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% hydration</string>
+    <string name="home_label_hydration_percentage">%1$s hydration</string>
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>
     <string name="home_motivation_almost_there">You\'re doing great! Almost there!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,8 @@
          locale-aware (NumberFormat) and the unit swapped independently.
          ============================================================================ -->
     <string name="unit_milliliters_format">%1$s ml</string>
-    <!-- current / goal, e.g. "1.2 L / 2.7 L" -->
-    <string name="percent_format">%1$d%%</string>
+    <!-- Percentage with sign appended in code; %1$s = value including the % sign, e.g. "85%" -->
+    <string name="percent_format">%1$s</string>
     <!-- Character counter, e.g. "12/15 characters"; %1$d = current length, %2$d = max -->
     <string name="character_count">%1$d/%2$d characters</string>
 
@@ -224,15 +224,15 @@
     <string name="beverage_delete_title">Delete Beverage?</string>
     <string name="beverage_show_in_quick_add">Show in Quick Add</string>
     <string name="beverage_hide_from_quick_add">Hide from Quick Add</string>
-    <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$d = percent -->
-    <string name="beverage_hydration_effectiveness">%1$d%% hydration effectiveness</string>
+    <!-- Preset effectiveness line, e.g. "150% hydration effectiveness"; %1$s = per cent value including the % sign -->
+    <string name="beverage_hydration_effectiveness">%1$s hydration effectiveness</string>
     <string name="beverage_name_label">Beverage Name</string>
     <string name="beverage_name_placeholder">e.g., Smoothie</string>
-    <string name="beverage_effectiveness_label">Hydration effectiveness (%)</string>
+    <string name="beverage_effectiveness_label" formatted="false">Hydration effectiveness (%)</string>
     <string name="beverage_effectiveness_placeholder">e.g., 100</string>
     <!-- Validation; %1$d = min, %2$d = max -->
     <string name="beverage_effectiveness_error">Enter a value between %1$d and %2$d</string>
-    <string name="beverage_effectiveness_hint">100%% counts the full amount toward your goal</string>
+    <string name="beverage_effectiveness_hint" formatted="false">100% counts the full amount toward your goal</string>
 
     <!-- Container preset sheet -->
     <string name="container_add_title">Add Container</string>
@@ -443,8 +443,8 @@
     <!-- Beverage types list/editor -->
     <string name="screen_beverage_types_title">Beverage Types</string>
     <string name="beverage_types_helper">Beverages offered in quick add. Tap to edit, drag to reorder.</string>
-    <!-- e.g. "150% hydration"; %1$d = per cent -->
-    <string name="beverage_hydration_short">%1$d%% hydration</string>
+    <!-- e.g. "150% hydration"; %1$s = per cent value including the % sign -->
+    <string name="beverage_hydration_short">%1$s hydration</string>
     <string name="beverage_reset_title">Reset Beverages?</string>
     <string name="beverage_reset_message">This restores the default beverage order, unhides all presets, and removes all custom beverages. This action cannot be undone.</string>
 
@@ -805,8 +805,8 @@
     <string name="home_label_time">Time</string>
     <!-- %1$s = minimum valid amount, %2$s = maximum valid amount (both with unit) -->
     <string name="home_error_amount_invalid">Please enter a valid amount (%1$s–%2$s)</string>
-    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$d%%</string>
-    <string name="home_label_effective_hydration">Effective Hydration: %1$d%%</string>
+    <string name="home_label_hydration_effectiveness">Hydration effectiveness: %1$s</string>
+    <string name="home_label_effective_hydration">Effective Hydration: %1$s</string>
     <string name="home_option_custom">Custom</string>
     <string name="home_beverage_effective_name">%1$s</string>
     <string name="home_beverage_effective_amount">%1$s</string>
@@ -843,8 +843,8 @@
     <string name="container_water_bottle">Water Bottle</string>
     <string name="container_large_bottle">Large Bottle</string>
 
-    <!-- Hydration percentage label, e.g. "80% hydration" -->
-    <string name="home_label_hydration_percentage">%1$d%% hydration</string>
+    <!-- Hydration percentage label, e.g. "80% hydration"; %1$s = per cent value including the % sign -->
+    <string name="home_label_hydration_percentage">%1$s hydration</string>
 
     <!-- Motivational messages -->
     <string name="home_motivation_goal_achieved">Amazing! You\'ve reached your daily goal!</string>


### PR DESCRIPTION
- Remove every literal per cent sign from formatted string resources: percent_format, beverage_hydration_effectiveness, beverage_hydration_short, home_label_hydration_effectiveness, home_label_effective_hydration and home_label_hydration_percentage now take a pre-formatted %1$s value (e.g. "85%"), so community translators can no longer break the %% escape; the French translations shipped with such broken escapes and crashed when picking a beverage or opening Statistics
- Apply the same corrections in all six locale files and fix beverage_effectiveness_hint rendering literally as "100%%" by adding formatted="false" to no-arg strings containing a per cent sign
- Update all ten call sites (home screen, water dialogues, beverage sheets, statistics, history chart and the Glance widget) to append the per cent sign in code
- Run lintDebug in CI with a baseline covering pre-existing issues, so StringFormatInvalid and StringFormatMatches fail future translation PRs instead of shipping crashes to users